### PR TITLE
feature/30-Created-the-goals-page

### DIFF
--- a/app/components/Goals.tsx
+++ b/app/components/Goals.tsx
@@ -1,0 +1,16 @@
+import React, { FC } from "react";
+import Link from "next/link";
+
+const Goals: FC = () => {
+    return (
+        <main>
+            <div className="flex justify-center mt-28">
+                <h1 className="w-[1020px] text-center text-6xl font-jidoka-newsreader">
+                    Goals
+                </h1>
+            </div>
+        </main>
+    )
+}
+
+export default Goals;

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -12,7 +12,7 @@ const Navbar: FC = () => {
           <Link href="#" legacyBehavior>
             <a className="hover:underline">Vision</a>
           </Link>
-          <Link href="#" legacyBehavior>
+          <Link href="/goals" legacyBehavior>
             <a className="hover:underline">Goals</a>
           </Link>
           <Link href="#" legacyBehavior>

--- a/app/goals/page.tsx
+++ b/app/goals/page.tsx
@@ -1,0 +1,5 @@
+import Goals from '../components/Goals';
+
+export default function GoalsPage() {
+  return <Goals />;
+}

--- a/cypress/component/Goals.cy.tsx
+++ b/cypress/component/Goals.cy.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import Goals from '@/app/components/Goals'
+
+describe("Goals Component", () => {
+    beforeEach(() => {
+      cy.mount(<Goals />);
+    });
+
+    it("should render the Goals component", () => {
+      cy.get("h1").should("exist").and("have.text", "Goals");
+    });
+
+    it("should have the correct styles", () => {
+      cy.get("h1")
+        .should("have.class", "text-6xl")
+        .and("have.class", "text-center")
+        .and("have.class", "font-jidoka-newsreader");
+    });
+  });

--- a/cypress/e2e/goals.cy.ts
+++ b/cypress/e2e/goals.cy.ts
@@ -1,0 +1,17 @@
+describe("Goals Page E2E", () => {
+    beforeEach(() => {
+      cy.visit("http://localhost:3000/goals"); // Asegúrate de que esta ruta es accesible en tu app
+    });
+
+    it("should load the goals page", () => {
+      cy.url().should("include", "/goals");
+    });
+
+    it("should display the Goals heading", () => {
+      cy.get("h1").should("be.visible").and("have.text", "Goals");
+    });
+
+    it("should have the correct styles", () => {
+      cy.get("h1").should("have.class", "text-6xl");
+    });
+  });


### PR DESCRIPTION
This PR introduces the Goals page, which will serve as the section where the community’s vision information will be displayed.

### **Changes**
✅ Created the Goals page with a placeholder title.
✅ Created the Component Goals used in the page.
✅ Developed an end-to-end (E2E) test to verify that the page loads correctly.
✅ Implemented a component test to ensure the Goals component renders properly.

### **Tests**
**e2e Test**
![image](https://github.com/user-attachments/assets/33473a3d-921b-4444-8368-88fe02f5c87c)


**Component Test**
![image](https://github.com/user-attachments/assets/14927ce1-3f35-4cab-a388-e6f442dfcc23)
